### PR TITLE
Support inputFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,40 @@ Additionally the action supports two optional parameters
 - `errorActionPreference` : select a suitable  value for the variable for executing the script. Allowed values are `stop`, `continue`, `silentlyContinue`. Default is `Stop`.
 - `failOnStandardError` : By default this is marked as `false`. But if this is marked as `true`, the action will fail if any errors are written to the error pipeline, or if any data is written to the Standard Error stream.
 
+#### Sample workflow to run inputFile using Azure PowerShell
+```yaml
+on: [push]
+
+name: AzurePowerShellSample
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: 'Checking out repo code'
+      uses: actions/checkout@v3
+
+    - name: Login via Az module
+      uses: azure/login@v1
+      with:
+        creds: ${{secrets.AZURE_CREDENTIALS}}
+        enable-AzPSSession: true 
+        
+    - name: Run Azure PowerShell script
+      uses: azure/powershell@v1
+      with:
+        inputFile: ./ps/run_az.ps1
+        azPSVersion: "latest"
+```
+
+It's similar as the example of `inlineScript`. But in this example, an `inputFile` is executed instead of an `inlineScript`. 
+
+`inputFile` should be a file in your repository. Thus, make sure the repository is checked out before the Azure PowerShell Action is used.
+
+In this example, `./ps/run_az.ps1` should be right under the repository root folder.
+
 ### Sample workflow to run Azure powershell actions in Azure US Government cloud
 
 ```

--- a/__tests__/ScriptRunner.test.ts
+++ b/__tests__/ScriptRunner.test.ts
@@ -1,17 +1,28 @@
 import ScriptRunner from '../src/ScriptRunner';
+import FileUtils from '../src/Utilities/FileUtils';
+import * as path from 'path';
 
 jest.mock('../src/Utilities/FileUtils');
 jest.mock('../src/Utilities/PowerShellToolRunner');
 jest.mock('../src/Utilities/ScriptBuilder');
 let scriptRunner: ScriptRunner;
 
+const mockCreateScriptFile = jest.fn();
+mockCreateScriptFile.mockImplementation((inlineScript) => {
+    return "/temp/" + inlineScript;
+});
+FileUtils.createScriptFile = mockCreateScriptFile;
+
+process.env['GITHUB_WORKSPACE'] = 'githubrepo';
+
 beforeAll(() => {
-    scriptRunner = new ScriptRunner("inlineScript", "Stop", true);
+    scriptRunner = new ScriptRunner("inlineScript","inputFile", "Stop", true);
 });
 
 afterEach(() => {
     jest.restoreAllMocks();
 });
+
 
 describe('Testing ScriptRunner', () => {
     let executeFileSpy;
@@ -22,5 +33,23 @@ describe('Testing ScriptRunner', () => {
         executeFileSpy.mockImplementationOnce(() => Promise.resolve());
         await scriptRunner.executeFile();
         expect(executeFileSpy).toHaveBeenCalled();
+    });
+
+    test('getScriptFile with inlineScript', () => {
+        expect(scriptRunner.getScriptFile("script", "")).toBe("/temp/script");
+    });
+
+    test('getScriptFile with inputfile', () => {
+        const inputFile = "inputfile.ps1";
+        const expectFilePath:string = path.join('githubrepo', inputFile);
+        expect(scriptRunner.getScriptFile("", inputFile)).toBe(expectFilePath);
+    });
+
+    test('getRunnerScript should pass', () => {
+        const expectedResult = `
+        $ErrorActionPreference = 'stop'
+        test.ps1
+        `;
+        expect(scriptRunner.getRunnerScript("test.ps1", "stop")).toBe(expectedResult);
     });
 });

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,10 @@ description: 'Automate your GitHub workflows using Azure PowerShell scripts.'
 inputs:
   inlineScript:
     description: 'Specify the Az PowerShell script here.'
-    required: true
+    required: false
+  inputFile:
+    description: 'Specify the Az PowerShell script file.'
+    required: false
   azPSVersion:
     description: 'Azure PS version to be used to execute the script, example: 1.8.0, 2.8.0, 3.4.0. To use the latest version, specify "latest".'
     required: true

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 import * as core from '@actions/core';
 import * as crypto from 'crypto';
 import Utils from './Utilities/Utils';
-import FileUtils from './Utilities/FileUtils';
 import ScriptRunner from './ScriptRunner';
 import InitializeAzure from './InitializeAzure';
 import { AzModuleInstaller } from './AzModuleInstaller';
@@ -19,13 +18,16 @@ async function main() {
         let userAgentString = (!!userAgentPrefix ? `${userAgentPrefix}+` : '') + `GITHUBACTIONS_${actionName}_${usrAgentRepo}`;
         core.exportVariable('AZURE_HTTP_USER_AGENT', userAgentString);
 
-        const inlineScript: string = core.getInput('inlineScript', { required: true });
+        const inlineScript: string = core.getInput('inlineScript', { required: false });
+        const inputFile: string = core.getInput('inputFile', { required: false });
+        core.debug(`inlineScript: ${inlineScript}`);
+        core.debug(`inputFile: ${inputFile}`);
         azPSVersion = core.getInput('azPSVersion', { required: true }).trim().toLowerCase();
         const errorActionPreference: string = core.getInput('errorActionPreference');
         const failOnStandardError = core.getInput('failOnStandardError').trim().toLowerCase() === "true";
         const githubToken = core.getInput('githubToken');
         console.log(`Validating inputs`);
-        validateInputs(inlineScript, errorActionPreference);
+        validateInputs(inlineScript, inputFile, errorActionPreference);
 
         const githubAuth = !githubToken || Utils.isGhes() ? undefined : `token ${githubToken}`;
         const installResult = await new AzModuleInstaller(azPSVersion, githubAuth).install();
@@ -36,21 +38,22 @@ async function main() {
         console.log(`Initializing Az Module Complete`);
 
         console.log(`Running Az PowerShell Script`);
-        const scriptRunner: ScriptRunner = new ScriptRunner(inlineScript, errorActionPreference, failOnStandardError);
+        const scriptRunner: ScriptRunner = new ScriptRunner(inlineScript, inputFile, errorActionPreference, failOnStandardError);
         await scriptRunner.executeFile();
         console.log(`Script execution Complete`);
     } catch(error) {
         core.setFailed(error);
     } finally {
-        FileUtils.deleteFile(ScriptRunner.filePath);
         // Reset AZURE_HTTP_USER_AGENT
         core.exportVariable('AZURE_HTTP_USER_AGENT', userAgentPrefix);
     }
 }
 
-function validateInputs(inlineScript: string, errorActionPreference: string) {
-    if (!inlineScript.trim()) {
-        throw new Error(`inlineScript is empty. Please enter a valid script.`);
+function validateInputs(inlineScript: string, inputFile: string, errorActionPreference: string) {
+    const inlineScriptIsNull = !inlineScript || !inlineScript.trim();
+    const inputFileIsNull = !inputFile || !inputFile.trim();
+    if(inlineScriptIsNull && inputFileIsNull){
+        throw new Error(`inlineScript and inputFile are both empty. Please enter a valid script or a valid input file.`);
     }
     if (azPSVersion !== "latest") {
         if (!Utils.isValidVersion(azPSVersion)) {


### PR DESCRIPTION
This PR will support the parameter `inputFile` in Azure PowerShell Action.

## Sample workflow to run inputFile using Azure PowerShell
```yaml
on: [push]

name: AzurePowerShellSample

jobs:

  build:
    runs-on: ubuntu-latest
    steps:

    - name: 'Checking out repo code'
      uses: actions/checkout@v3

    - name: Login via Az module
      uses: azure/login@v1
      with:
        creds: ${{secrets.AZURE_CREDENTIALS}}
        enable-AzPSSession: true 
        
    - name: Run Azure PowerShell script
      uses: azure/powershell@v1
      with:
        inputFile: ./ps/run_az.ps1
        azPSVersion: "latest"
```
It's similar as the example of `inlineScript`. But in this example, an `inputFile` is executed instead of an `inlineScript`. 
`inputFile` should be a file in your repository. Thus, make sure the repository is checked out before the Azure PowerShell Action is used.
In this example, `./ps/run_az.ps1` should be right under the repository root folder.

## Test

- The unit tests are added.
- The manual tests are in this PR: [[Manual Test] Support inputFile](https://github.com/YanaXu/powershellActionFork/pull/1).
  - [Positive test cases](https://github.com/YanaXu/powershellActionFork/actions/runs/4784355853/workflow)
  - [Negative test cases](https://github.com/YanaXu/powershellActionFork/actions/runs/4784355845)
