### PR TITLE
Support MacOS and self-hosted runner

### DIFF
--- a/__tests__/AzModuleInstaller.test.ts
+++ b/__tests__/AzModuleInstaller.test.ts
@@ -56,37 +56,6 @@ describe("Testing AzModuleInstaller", () => {
         expect(spyTryInstallingLatest).toBeCalledTimes(1);
         expect(mockTryInstalledTrue).toBeCalledTimes(4);
     });
-    test("install with version 1.1.1 available as folder", async () => {
-        mockPathExists.mockImplementation((path) => path === "C:\\Modules\\az_1.1.1");
-        const installer = new AzModuleInstaller("1.1.1");
-        const spyTryInstallingLatest = jest.spyOn(<any>installer, "tryInstallingLatest");
-        const spyTryInstallFromFolder = jest.spyOn(<any>installer, "tryInstallFromFolder");
-        const mockTryInstalledTrue = jest.fn(async () => expect(installer["installResult"]["isInstalled"]).toBeTruthy());
-        installer["tryInstallFromZip"] = mockTryInstalledTrue;
-        installer["tryInstallFromGHRelease"] = mockTryInstalledTrue;
-        installer["tryInstallFromPSGallery"] = mockTryInstalledTrue;
-        const result = await installer.install();
-        expect(result).toEqual({ isInstalled: true, moduleSource: "hostedAgentFolder" });
-        expect(spyTryInstallingLatest).toBeCalledTimes(1);
-        expect(spyTryInstallFromFolder).toBeCalledTimes(1);
-        expect(mockTryInstalledTrue).toBeCalledTimes(3);
-    });
-    test("install with version 1.1.1 available as zip", async () => {
-        mockPathExists.mockImplementation((path) => path === "C:\\Modules\\az_1.1.1.zip");
-        const installer = new AzModuleInstaller("1.1.1");
-        const spyTryInstallingLatest = jest.spyOn(<any>installer, "tryInstallingLatest");
-        const spyTryInstallFromFolder = jest.spyOn(<any>installer, "tryInstallFromFolder");
-        const spyTryInstallFromZip = jest.spyOn(<any>installer, "tryInstallFromZip");
-        const mockTryInstalledTrue = jest.fn(async () => expect(installer["installResult"]["isInstalled"]).toBeTruthy());
-        installer["tryInstallFromGHRelease"] = mockTryInstalledTrue;
-        installer["tryInstallFromPSGallery"] = mockTryInstalledTrue;
-        const result = await installer.install();
-        expect(result).toEqual({ isInstalled: true, moduleSource: "hostedAgentZip" });
-        expect(spyTryInstallingLatest).toBeCalledTimes(1);
-        expect(spyTryInstallFromFolder).toBeCalledTimes(1);
-        expect(spyTryInstallFromZip).toBeCalledTimes(1);
-        expect(mockTryInstalledTrue).toBeCalledTimes(2);
-    });
     test("install with version 1.1.1 from GHRelease", async () => {
         const installer = new AzModuleInstaller("1.1.1");
         installer["getDownloadUrlFromGHRelease"] = jest.fn().mockReturnValue("downloadUrl");

--- a/__tests__/Utilities/Utils.test.ts
+++ b/__tests__/Utilities/Utils.test.ts
@@ -42,21 +42,16 @@ describe('Testing setPSModulePath', () => {
         process.env.RUNNER_OS = savedRunnerOS;
     });
 
-    test('PSModulePath with azPSVersion non-empty', () => {
+    test('PSModulePath with azPSVersion non-empty', async () => {
         process.env.RUNNER_OS = "Windows";
-        Utils.setPSModulePath(version);
+        await Utils.setPSModulePath(version);
         expect(process.env.PSModulePath).toContain(version);
     });
-    test('PSModulePath with azPSVersion empty', () => {
+    test('PSModulePath with azPSVersion empty', async () => {
         process.env.RUNNER_OS = "Linux";
         const prevPSModulePath = process.env.PSModulePath;
-        Utils.setPSModulePath();
+        await Utils.setPSModulePath();
         expect(process.env.PSModulePath).not.toEqual(prevPSModulePath);
-    });
-    test('setPSModulePath should throw for MacOS', () => {
-        process.env.RUNNER_OS = "Darwin";
-        expect(() => Utils.setPSModulePath()).toThrow();
-        expect(() => Utils.setPSModulePath(version)).toThrow();
     });
 });
 
@@ -93,7 +88,6 @@ describe('Testing isHostedAgent', () => {
     test('Should return true when file layout check script returns true', async () => {
         mockExecutePowerShellCommandOutput = "True";
         const isHostedAgentResult = await Utils.isHostedAgent("/usr/share");
-        expect(mockPowerShellToolRunnerInit).toHaveBeenCalledTimes(1);
         expect(mockExecutePowerShellCommand).toHaveBeenCalledTimes(1);
         expect(mockExecutePowerShellCommand.mock.calls[0][0]).toBe('Test-Path (Join-Path "/usr/share" "az_*")');
         expect(isHostedAgentResult).toBeTruthy();
@@ -136,7 +130,6 @@ describe('Testing saveAzModule', () => {
     test('Should run without throwing when script succeeds with exit code 0', async () => {
         mockExecutePowerShellScriptBlockExitCode = 0;
         await Utils.saveAzModule("1.1.1", "/usr/share/az_1.1.1");
-        expect(mockPowerShellToolRunnerInit).toHaveBeenCalledTimes(1);
         expect(mockExecutePowerShellScriptBlock).toHaveBeenCalledTimes(1);
         expect(mockExecutePowerShellScriptBlock.mock.calls[0][0]).toContain(
             "Save-Module -Path /usr/share/az_1.1.1 -Name Az -RequiredVersion 1.1.1 -Force -ErrorAction Stop");

--- a/src/AzModuleInstaller.ts
+++ b/src/AzModuleInstaller.ts
@@ -4,6 +4,8 @@ import * as os from 'os';
 import { ArchiveTools } from './Utilities/ArchiveTools';
 import FileUtils from './Utilities/FileUtils';
 import Utils from './Utilities/Utils';
+import path from 'path';
+import Constants from './Constants';
 
 export interface InstallResult {
     moduleSource: string;
@@ -36,20 +38,11 @@ export class AzModuleInstaller {
         };
         const platform = (process.env.RUNNER_OS || os.type())?.toLowerCase();
         core.debug(`Platform: ${platform}`);
-        switch(platform) {
-            case "windows":
-            case "windows_nt":
-                this.isWin = true;
-                this.moduleRoot = "C:\\Modules";
-                this.modulePath = `${this.moduleRoot}\\az_${this.version}`
-                break;
-            case "linux":
-                this.moduleRoot = "/usr/share";
-                this.modulePath = `${this.moduleRoot}/az_${this.version}`
-                break;
-            default:
-                throw `OS ${platform} not supported`;
+        this.moduleRoot = Utils.getDefaultAzInstallFolder(platform);
+        if(platform == "windows" || platform == "windows_nt"){
+            this.isWin = true;
         }
+        this.modulePath = path.join(this.moduleRoot, `${Constants.prefix}${this.version}`);
         this.moduleZipPath = `${this.modulePath}.zip`;
     }
 
@@ -137,7 +130,7 @@ export class AzModuleInstaller {
             };
         } catch (err) {
             core.debug(err);
-            console.log("Download from GHRelease failed, will fallback to PSGallery");
+            core.info("Download from GHRelease failed, will fallback to PSGallery");
         }
     }
 

--- a/src/InitializeAzure.ts
+++ b/src/InitializeAzure.ts
@@ -5,13 +5,13 @@ import Constants from "./Constants";
 
 export default class InitializeAzure {
     static async importAzModule(azPSVersion: string) {
-        Utils.setPSModulePath();
+        await Utils.setPSModulePath();
         if (azPSVersion === "latest") {
             azPSVersion = await Utils.getLatestModule(Constants.moduleName);
         } else {
             await Utils.checkModuleVersion(Constants.moduleName, azPSVersion);
         }
         core.debug(`Az Module version used: ${azPSVersion}`);
-        Utils.setPSModulePath(`${Constants.prefix}${azPSVersion}`);
+        await Utils.setPSModulePath(`${Constants.prefix}${azPSVersion}`);
     }
 }

--- a/src/ScriptRunner.ts
+++ b/src/ScriptRunner.ts
@@ -38,7 +38,6 @@ export default class ScriptRunner {
             this.inlineScript, this.errorActionPreference);
         ScriptRunner.filePath = await FileUtils.createScriptFile(scriptToExecute);
         core.debug(`script file to run: ${ScriptRunner.filePath}`);
-        await PowerShellToolRunner.init();
         const exitCode: number = await PowerShellToolRunner.executePowerShellScriptBlock(ScriptRunner.filePath, options);
         if (exitCode !== 0) {
             core.setOutput(`Azure PowerShell exited with code:`, exitCode.toString());

--- a/src/Utilities/ArchiveTools.ts
+++ b/src/Utilities/ArchiveTools.ts
@@ -34,7 +34,6 @@ export class ArchiveTools {
             $ProgressPreference = 'SilentlyContinue'
             Expand-Archive -Path ${zipPath} -DestinationPath ${destination}
             $ProgressPreference = $prevProgressPref`;
-        await PowerShellToolRunner.init();
         const exitCode = await PowerShellToolRunner.executePowerShellScriptBlock(script);
         if (exitCode != 0) {
             throw new Error(`Extraction using Expand-Archive cmdlet failed from ${zipPath} to ${destination}`);

--- a/src/Utilities/PowerShellToolRunner.ts
+++ b/src/Utilities/PowerShellToolRunner.ts
@@ -11,10 +11,12 @@ export default class PowerShellToolRunner {
     }
 
     static async executePowerShellCommand(command: string, options: any = {}) {
+        await PowerShellToolRunner.init();
         await exec.exec(`"${PowerShellToolRunner.psPath}" -NoLogo -NoProfile -NonInteractive -Command ${command}`, [], options);
     }
 
     static async executePowerShellScriptBlock(scriptBlock: string, options: any = {}): Promise<number> {
+        await PowerShellToolRunner.init();
         const exitCode: number = await exec.exec(`"${PowerShellToolRunner.psPath}" -NoLogo -NoProfile -NonInteractive -Command`,
                      [scriptBlock], options);
         return exitCode;


### PR DESCRIPTION
The features in this PR:

- Support MacOS 
- Support Self-Hosted Runner
  - Azure PowerShell Action will sequentially check which of the following directories can save the downloaded Azure PowerShell module:
    - default path: 
      - **windows**: C:\Modules
      - **linux**: /usr/share
      - **other OS**: none
    -  $RUNNER_TOOL_CACHE
        - Refer to [this page](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) for the description of `RUNNER_TOOL_CACHE`: `The path to the directory containing preinstalled tools for GitHub-hosted runners. `
    - the current workspace folder

The test has been done on below runners with `azPSVersion` values (`latest`, `9.7.0`, `10.4.0`, `11.0.0`):
  - GitHub-hosted Runners: 
    - ubuntu-latest
    - windows-latest
    - macos-latest
    - macos-11
    - macos-12
    - macos-13
- Self-hosted Runners
    - windows
    - ubuntu
 
